### PR TITLE
Fetch tag's security status from devguide

### DIFF
--- a/release.py
+++ b/release.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import datetime
 import glob
 import hashlib
+import json
 import optparse
 import os
 import re
@@ -19,6 +20,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import urllib.request
 from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -203,6 +205,13 @@ class Tag:
     @property
     def is_feature_freeze_release(self) -> bool:
         return self.level == "b" and self.serial == 1
+
+    @property
+    def is_security_release(self) -> bool:
+        url = "https://raw.githubusercontent.com/python/devguide/refs/heads/main/include/release-cycle.json"
+        with urllib.request.urlopen(url) as response:
+            data = json.loads(response.read())
+        return str(data[self.basic_version]["status"]) == "security"
 
     @property
     def nickname(self) -> str:

--- a/release.py
+++ b/release.py
@@ -208,7 +208,7 @@ class Tag:
 
     @property
     def is_security_release(self) -> bool:
-        url = "https://raw.githubusercontent.com/python/devguide/refs/heads/main/include/release-cycle.json"
+        url = "https://peps.python.org/api/release-cycle.json"
         with urllib.request.urlopen(url) as response:
             data = json.loads(response.read())
         return str(data[self.basic_version]["status"]) == "security"

--- a/run_release.py
+++ b/run_release.py
@@ -194,7 +194,6 @@ class ReleaseDriver:
         ssh_user: str,
         sign_gpg: bool,
         ssh_key: str | None = None,
-        security_release: bool = False,
         first_state: Task | None = None,
     ) -> None:
         self.tasks = tasks
@@ -221,11 +220,10 @@ class ReleaseDriver:
             self.db["ssh_key"] = ssh_key
         if not self.db.get("sign_gpg"):
             self.db["sign_gpg"] = sign_gpg
-        if not self.db.get("security_release"):
-            self.db["security_release"] = security_release
-
         if not self.db.get("release"):
             self.db["release"] = release_tag
+        if not self.db.get("security_release"):
+            self.db["security_release"] = self.db["release"].is_security_release
 
         print("Release data: ")
         print(f"- Branch: {release_tag.branch}")
@@ -1307,13 +1305,6 @@ def main() -> None:
         help="Path to the SSH key file to use for authentication",
         type=str,
     )
-    parser.add_argument(
-        "--security-release",
-        dest="security_release",
-        action="store_true",
-        default=False,
-        help="Indicate this is a security release (only checks for Linux files)",
-    )
     args = parser.parse_args()
 
     auth_key = args.auth_key or os.getenv("AUTH_INFO")
@@ -1409,7 +1400,6 @@ fix these things in this script so it also supports your platform.
         ssh_user=args.ssh_user,
         sign_gpg=not no_gpg,
         ssh_key=args.ssh_key,
-        security_release=args.security_release,
         tasks=tasks,
     )
     automata.run()


### PR DESCRIPTION
Rather than the release manager having to remember to pass `--security`, we can look up the branch status from the devguide:

https://github.com/python/devguide/blob/main/include/release-cycle.json

